### PR TITLE
chore: remove mandatory username/password enforcement

### DIFF
--- a/element-templates/kafka-connector.json
+++ b/element-templates/kafka-connector.json
@@ -45,12 +45,10 @@
       "description": "Provide the username (must have permissions to produce message to the topic)",
       "group": "authentication",
       "type": "String",
+      "optional": true,
       "binding": {
         "type": "zeebe:input",
         "name": "authentication.username"
-      },
-      "constraints": {
-        "notEmpty": true
       }
     },
     {
@@ -58,12 +56,10 @@
       "description": "Provide a password for the user",
       "group": "authentication",
       "type": "String",
+      "optional": true,
       "binding": {
         "type": "zeebe:input",
         "name": "authentication.password"
-      },
-      "constraints": {
-        "notEmpty": true
       }
     },
     {

--- a/src/main/java/io/camunda/connector/model/KafkaConnectorRequest.java
+++ b/src/main/java/io/camunda/connector/model/KafkaConnectorRequest.java
@@ -23,7 +23,7 @@ public class KafkaConnectorRequest {
   protected static final String CLIENT_DNS_LOOKUP_RECOMMENDED_VALUE = "use_all_dns_ips";
   protected static final String ACKS_RECOMMENDED_VALUE = "all";
 
-  @Valid @NotNull @Secret private KafkaAuthentication authentication;
+  @Valid @Secret private KafkaAuthentication authentication;
   @Valid @NotNull @Secret private KafkaTopic topic;
   @Valid @NotNull private KafkaMessage message;
 
@@ -67,8 +67,10 @@ public class KafkaConnectorRequest {
     Properties props = new Properties();
 
     // Step 1: collect properties directly from the form
-    Properties authProps = this.authentication.produceAuthenticationProperties();
-    props.putAll(authProps);
+    if (authentication != null) {
+      Properties authProps = this.authentication.produceAuthenticationProperties();
+      props.putAll(authProps);
+    }
 
     Properties topicProps = this.topic.produceTopicProperties();
     props.putAll(topicProps);

--- a/src/test/resources/requests/fail-test-cases.json
+++ b/src/test/resources/requests/fail-test-cases.json
@@ -1,27 +1,12 @@
 [
   {
-    "testDescription": "No auth",
-    "topic":{
-      "bootstrapServers":"kafka-stub.kafka.cloud:1234",
-      "topicName":"some-awesome-topic"
-    },
-    "message":{
-      "keySerializer":"org.apache.kafka.common.serialization.StringSerializer",
-      "key":"Happy",
-      "valueSerializer":"org.apache.kafka.common.serialization.StringSerializer",
-      "value":"Case"
-    }
-  },
-  {
     "testDescription": "No topic",
     "authentication":{
       "username":"myLogin",
       "password":"mySecretPassword"
     },
     "message":{
-      "keySerializer":"org.apache.kafka.common.serialization.StringSerializer",
       "key":"Happy",
-      "valueSerializer":"org.apache.kafka.common.serialization.StringSerializer",
       "value":"Case"
     }
   },
@@ -46,9 +31,7 @@
       "topicName":"some-awesome-topic"
     },
     "message":{
-      "keySerializer":"org.apache.kafka.common.serialization.StringSerializer",
       "key":"Happy",
-      "valueSerializer":"org.apache.kafka.common.serialization.StringSerializer",
       "value":"Case"
     }
   },
@@ -62,9 +45,7 @@
       "topicName":"some-awesome-topic"
     },
     "message":{
-      "keySerializer":"org.apache.kafka.common.serialization.StringSerializer",
       "key":"Happy",
-      "valueSerializer":"org.apache.kafka.common.serialization.StringSerializer",
       "value":"Case"
     }
   },
@@ -78,9 +59,7 @@
       "bootstrapServers":"kafka-stub.kafka.cloud:1234"
     },
     "message":{
-      "keySerializer":"org.apache.kafka.common.serialization.StringSerializer",
       "key":"Happy",
-      "valueSerializer":"org.apache.kafka.common.serialization.StringSerializer",
       "value":"Case"
     }
   },
@@ -94,9 +73,7 @@
       "topicName":"some-awesome-topic"
     },
     "message":{
-      "keySerializer":"org.apache.kafka.common.serialization.StringSerializer",
       "key":"Happy",
-      "valueSerializer":"org.apache.kafka.common.serialization.StringSerializer",
       "value":"Case"
     }
   },
@@ -111,8 +88,6 @@
       "topicName":"some-awesome-topic"
     },
     "message":{
-      "keySerializer":"org.apache.kafka.common.serialization.StringSerializer",
-      "valueSerializer":"org.apache.kafka.common.serialization.StringSerializer",
       "value":"Case"
     }
   },
@@ -127,9 +102,7 @@
       "topicName":"some-awesome-topic"
     },
     "message":{
-      "keySerializer":"org.apache.kafka.common.serialization.StringSerializer",
-      "key":"Happy",
-      "valueSerializer":"org.apache.kafka.common.serialization.StringSerializer"
+      "key":"Happy"
     }
   }
 ]


### PR DESCRIPTION
## Description

Remove mandatory username/password enforcement.

If customer does not supply username and password - connector still would work. The idea behind is that Kafka connector in the self-managed DMZ instance may not require username and password.

However, if customer provides any value, the connector should fail.

## Related issues

- #13

closes #13

