### PR TITLE
chore: pre-release sdk, runtime bump to 0.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-parent</artifactId>
-    <version>0.3.0</version>
+    <version>0.4.0-alpha1</version>
     <relativePath></relativePath>    
   </parent>
 
@@ -149,7 +149,7 @@ except in compliance with the proprietary license.</license.inlineheader>
         <dependency>
           <groupId>io.camunda.connector</groupId>
           <artifactId>connector-runtime-cloud</artifactId>
-          <version>0.3.0</version>
+          <version>0.4.0-alpha2</version>
         </dependency>
         <dependency>
           <groupId>io.camunda.connector</groupId>


### PR DESCRIPTION
chore: pre-release sdk, runtime bump to 0.4.0

